### PR TITLE
Fix alarm interpretation

### DIFF
--- a/custom_components/bms_connector/bms/seplos/v2/alarms_teledata.py
+++ b/custom_components/bms_connector/bms/seplos/v2/alarms_teledata.py
@@ -71,7 +71,7 @@ def parse_teledata_info(info_str):
         result.tempAlarm.append(int(info_str[cursor:cursor+2], 16))
         cursor += 2
 
-    for attribute in ['currentAlarm', 'voltageAlarm', 'customAlarms', 'alarmEvent0', 'alarmEvent1', 'alarmEvent2', 'alarmEvent3', 'alarmEvent4', 'alarmEvent5', 'onOffState', 'equilibriumState0', 'equilibriumState1', 'systemState', 'disconnectionState0', 'disconnectionState1', 'alarmEvent6', 'alarmEvent7']:
+    for attribute in ['currentAlarm', 'voltageAlarm', 'customAlarms', 'alarmEvent1', 'alarmEvent2', 'alarmEvent3', 'alarmEvent4', 'alarmEvent5', 'alarmEvent6', 'onOffState', 'equilibriumState0', 'equilibriumState1', 'systemState', 'disconnectionState0', 'disconnectionState1', 'alarmEvent7', 'alarmEvent8']:
         if remaining_length() < 2:
             return result
         setattr(result, attribute, int(info_str[cursor:cursor+2], 16))


### PR DESCRIPTION
Fixed the attribute list in `parse_teledata_info` by removing extra `alarmEvent0` and updating rest of alarm events according to Seplos specification document.

Fixes #76.